### PR TITLE
Move package version to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-offline",
-  "version": "1.1.0",
+  "version": "2.1.0",
   "description": "Redux Offline-First Architecture",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Per the original release notes on jevakallio/redux-offline/releases/2.0.0, the defining breaking change from v1 to v2 series was the removal of `createOfflineStore` method in preference of of the `offline` store enhancer.  This change was introduced in e32ef99662423a5e6b498788b706b42f31fa0751, which is in the history of the redux-offline/redux-offine fork.  

The presence of this change objectively marks this package as being a part of the v2 major series on the basis of API compatibility.  The improvements introduced to redux-offline/redux-offine since forking from jevakallio/redux-offline subjectively appear to the worthy of a +0.1 version bump.